### PR TITLE
unhandled promise rejection failed to delete storage directory

### DIFF
--- a/examples/NavigationPlayground/app/SwitchWithStacks.tsx
+++ b/examples/NavigationPlayground/app/SwitchWithStacks.tsx
@@ -5,6 +5,7 @@ import {
   StatusBar,
   StyleSheet,
   View,
+  Platform,
 } from 'react-native';
 import { createStackNavigator, createSwitchNavigator } from 'react-navigation';
 import { Button } from './commonComponents/ButtonWithMargin';
@@ -53,7 +54,7 @@ class HomeScreen extends React.Component<any, any> {
   };
 
   signOutAsync = async () => {
-    await AsyncStorage.clear();
+    Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()
     this.props.navigation.navigate('Auth');
   };
 }
@@ -73,7 +74,7 @@ class OtherScreen extends React.Component<any, any> {
   }
 
   signOutAsync = async () => {
-    await AsyncStorage.clear();
+    Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()
     this.props.navigation.navigate('Auth');
   };
 }


### PR DESCRIPTION
with:

await AsyncStorage.clear();

I'm getting this in ios:

unhandled promise rejection failed to delete storage directory

found this:

https://stackoverflow.com/questions/46736268/react-native-asyncstorage-clear-is-failing-on-ios

switched to use this instead:

await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove)

but that causes unhandled promise rejection in android.

this is working:

Platform.OS === 'ios' ? await AsyncStorage.getAllKeys().then(AsyncStorage.multiRemove) : await AsyncStorage.clear()

Please provide enough information so that others can review your pull request:

## Motivation

Explain the **motivation** for making this change. What existing problem does the pull request solve?

## Test plan

Demonstrate the code is solid. Example: the exact commands you ran and their output, screenshots / videos if the pull request changes UI.

Make sure you test on both platforms if your change affects both platforms.

The code must pass tests.

## Code formatting

Look around. Match the style of the rest of the codebase. Run `yarn format` before committing.

## Changelog

Add an entry under the "Unreleased" heading in [CHANGELOG.md](https://github.com/react-navigation/react-navigation/blob/master/CHANGELOG.md#unreleased) which explains your change.
